### PR TITLE
Order cancelation and payment state fixes

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -628,6 +628,7 @@ module Spree
 
     def after_cancel
       shipments.each { |shipment| shipment.cancel! }
+      payments.pending.each { |payment| payment.cancel! } if Spree::Config[:auto_capture_on_dispatch]
       payments.completed.each { |payment| payment.cancel! }
       send_cancel_email
       self.update!

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -69,7 +69,19 @@ module Spree
       end
 
       def cancel!
-        payment_method.cancel(response_code)
+        protect_from_connection_error do
+
+          response = payment_method.cancel(response_code)
+
+          record_response(response)
+
+          if response.success?
+            self.response_code = response.authorization
+            self.void
+          else
+            gateway_error(response)
+          end
+        end
       end
 
       def gateway_options


### PR DESCRIPTION
cancel pending payments when an order is canceled, if auto_capture_on_dispatch is true.
log gateway response when payment is canceled.
update payment status to void when payment is canceled.
